### PR TITLE
https://code.visualstudio.com/docs/nodejs/nodejs-debugging

### DIFF
--- a/.debug
+++ b/.debug
@@ -1,0 +1,1 @@
+sentence Developer Model Noun -g -f

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,13 +5,17 @@
     "version": "0.2.0",
     "configurations": [
         
+
+        
         {
             "type": "node",
+            "cwd": "/Users/toukubo/storyteller_core/",
             "request": "launch",
             "runtimeExecutable": "node",
             "name": "Sentence Command",
             "program": "${workspaceFolder}/storyteller.js",
-            "runtimeArgs":["story","tell"]
+            "runtimeArgs":["--debug"]
+            // "runtimeArgs":["Developer Model Generation -g -f -command=sentence"]
 
         }
     ]

--- a/bin/sentence
+++ b/bin/sentence
@@ -1,3 +1,4 @@
 #!/usr/bin/env node
+console.log("mark 0")
 require('../storyteller.js')
 

--- a/models/generation.js
+++ b/models/generation.js
@@ -59,15 +59,12 @@ console.dir(this)
         interpreters.push(defaultInterpreter)
         var frameworkClass = require('./framework.js')
         let framework = frameworkClass.findById(template.framework)
-        console.log("framework : ")
-console.dir(framework)
 
         var interpreter_file_path = process.cwd() + "/verbs/" + framework.name + "/" + "interpreter.js"
         var layerInterpreter = require(interpreter_file_path)
         interpreters.push(layerInterpreter)
         var sentence = this.sentence
-        console.log("sentence : ")
-console.dir(sentence)
+
 
         interpreters.forEach(function (interpreter) {
             hay = interpreter._interpret(hay, sentence.first_objective)
@@ -78,13 +75,16 @@ console.dir(sentence)
         return template
     }
     print(){
-        console.log(this.generatedText)
+        this.generated.forEach(generated => {
+            console.log(generated.generatedText)
+            
+        });
     }
     placement(){
 
         var placement = require('./placement.js')
         placement.generation = this // no. @TODO
-        // 
+            // 
         placement.create()
     }
 

--- a/test/undefined
+++ b/test/undefined
@@ -1,0 +1,1 @@
+undefined

--- a/utils/parse.js
+++ b/utils/parse.js
@@ -6,9 +6,18 @@ var fileNameIndex = commandFullPath.lastIndexOf("/") + 1;
 req.command = commandFullPath.substr(fileNameIndex);
 
 args = require('minimist')(process.argv.slice(2))
-// console.log("args : ")
-// console.dir(args)
+if(process.execArgv[0]==="--debug"){
+    let application_path = process.argv[1]
+    let path = require('path')
+    let application_dir = path.dirname(application_path)
+    var args_text = fs.readFileSync(application_dir+'/.debug', 'utf-8')
+    var args_splited = args_text.split(" ")
+    req.command = args_splited.shift()
+    // var new_args =  args_splited.filter(n,index => index !== 0)
+    args_text = args_splited.join(' ')
 
+    args = require('minimist')(args_splited)
+}
 
 LAYER = args.layer != undefined?args.layer:LAYER
 

--- a/utils/render.js
+++ b/utils/render.js
@@ -1,3 +1,0 @@
-function render(){
-    return mustache.render(template, model);
-}


### PR DESCRIPTION
https://code.visualstudio.com/docs/nodejs/nodejs-debugging

but nodejs debugger specifies the order of the args, also it needs "node" or npm for lunch.

since in storyteller the sentence commands, story commands are required to be a the command name, we use ".debug" file to set the command line to be run from the debugg.
and runtime args in debugger config in nofe ( launch.json ) we use the --debug option. 
by checking this, the special parse to the .debug file contents.
